### PR TITLE
dockerfile: add rsvg2-bin for pcbdraw to png

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -yqq install \
 	fakeroot \
 	git \
 	jq \
+	librsvg2-bin \
 	libxdo3 \
 	python3 \
 	python3-colorama \


### PR DESCRIPTION
pcbdraw requires librsvg2-bin in order to produce PNG images instead of SVGs

Signed-off-by: Tillmann Heidsieck <theidsieck@leenox.de>